### PR TITLE
[2주차] 플레이어 이름으로 검색 시 랭크 데이터 정보 추가

### DIFF
--- a/fixtures/ranks.js
+++ b/fixtures/ranks.js
@@ -1,0 +1,34 @@
+const ranks = [
+  {
+    leagueId: '1',
+    queueType: 'RANKED_FLEX_SR',
+    tier: 'PLATINUM',
+    rank: 'IV',
+    summonerId: '1',
+    summonerName: '최하누리',
+    leaguePoints: 1,
+    wins: 24,
+    losses: 16,
+    veteran: false,
+    inactive: false,
+    freshBlood: true,
+    hotStreak: false
+  },
+  {
+    leagueId: '2',
+    queueType: 'RANKED_SOLO_5x5',
+    tier: 'DIAMOND',
+    rank: 'II',
+    summonerId: '2',
+    summonerName: '최하누리',
+    leaguePoints: 75,
+    wins: 145,
+    losses: 132,
+    veteran: false,
+    inactive: false,
+    freshBlood: false,
+    hotStreak: false
+  },
+];
+
+export default ranks;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -16,6 +16,8 @@ describe('App', () => {
         userName: '',
       },
       summoner: {},
+      soloRank: {},
+      subRank: {},
     }));
   });
 

--- a/src/actions.test.js
+++ b/src/actions.test.js
@@ -3,7 +3,8 @@ import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 
 import {
-  loadSummoners, setSummoner,
+  loadSummoners,
+  setSummoner,
 } from './slice';
 
 const middlewares = [thunk];
@@ -17,6 +18,8 @@ describe('actions', () => {
   describe('loadSummoners', () => {
     store = mockStore({
       summoner: {},
+      soloRank: {},
+      subRank: {},
     });
 
     it('dispatches setSummoner', async () => {

--- a/src/components/PlayerInfo.jsx
+++ b/src/components/PlayerInfo.jsx
@@ -1,4 +1,17 @@
-export default function PlayerInfo({ name, summonerLevel }) {
+import { memo } from 'react';
+
+function PlayerInfo({
+  name,
+  summonerLevel,
+  soloRank,
+  subRank,
+}) {
+  if (!name) {
+    return (
+      <p>소환사명을 검색해주세요.</p>
+    );
+  }
+
   return (
     <>
       <div>
@@ -11,6 +24,28 @@ export default function PlayerInfo({ name, summonerLevel }) {
         {' : '}
         {summonerLevel}
       </div>
+      <div>
+        솔로랭크
+        {' : '}
+        {`${soloRank.tier} ${soloRank.rank} ${soloRank.leaguePoints}`}
+      </div>
+      <div>
+        전적
+        {' : '}
+        {`${soloRank.wins}승 ${soloRank.losses}패`}
+      </div>
+      <div>
+        자유랭크
+        {' : '}
+        {`${subRank.tier} ${subRank.rank} ${subRank.leaguePoints}`}
+      </div>
+      <div>
+        전적
+        {' : '}
+        {`${subRank.wins}승 ${subRank.losses}패`}
+      </div>
     </>
   );
 }
+
+export default memo(PlayerInfo);

--- a/src/components/PlayerInfo.test.jsx
+++ b/src/components/PlayerInfo.test.jsx
@@ -4,14 +4,47 @@ import PlayerInfo from './PlayerInfo';
 
 describe('PlayerInfo', () => {
   it('renders', () => {
+    const soloRank = {
+      tier: '다이아몬드',
+      rank: '2',
+      leaguePoints: '75LP',
+      wins: '145',
+      losses: '132',
+    }
+
+    const subRank = {
+      tier: '플레티넘',
+      rank: '4',
+      leaguePoints: '1LP',
+      wins: '24',
+      losses: '16',
+    }
+
     const { container } = render(
       <PlayerInfo
         name="최하누리"
         summonerLevel={30}
+        soloRank={soloRank}
+        subRank={subRank}
       />,
     );
 
     expect(container).toHaveTextContent('소환사명');
+    expect(container).toHaveTextContent('최하누리');
+
     expect(container).toHaveTextContent('레벨');
+    expect(container).toHaveTextContent('30');
+
+    expect(container).toHaveTextContent('솔로랭크');
+    expect(container).toHaveTextContent('다이아몬드 2 75LP');
+
+    expect(container).toHaveTextContent('전적');
+    expect(container).toHaveTextContent('145승 132패');
+
+    expect(container).toHaveTextContent('자유랭크');
+    expect(container).toHaveTextContent('플레티넘 4 1LP');
+
+    expect(container).toHaveTextContent('전적');
+    expect(container).toHaveTextContent('24승 16패');
   });
 });

--- a/src/components/PlayerInfoContainer.jsx
+++ b/src/components/PlayerInfoContainer.jsx
@@ -3,15 +3,24 @@ import { useSelector } from 'react-redux';
 import PlayerInfo from './PlayerInfo';
 
 export default function PlayerInfoContainer() {
-  const { name, summonerLevel } = useSelector((state) => ({
+  const {
+    name,
+    summonerLevel,
+    soloRank,
+    subRank,
+  } = useSelector((state) => ({
     name: state.summoner.name,
     summonerLevel: state.summoner.summonerLevel,
+    soloRank: state.soloRank,
+    subRank: state.subRank,
   }));
 
   return (
     <PlayerInfo
       name={name}
       summonerLevel={summonerLevel}
+      soloRank={soloRank}
+      subRank={subRank}
     />
   );
 }

--- a/src/components/PlayerInfoContainer.test.jsx
+++ b/src/components/PlayerInfoContainer.test.jsx
@@ -18,6 +18,20 @@ describe('PlayerInfoContainer', () => {
         name: '최하누리',
         summonerLevel: '30',
       },
+      soloRank: {
+        tier: '다이아몬드',
+        rank: '2',
+        leaguePoints: '75LP',
+        wins: '145',
+        losses: '132',
+      },
+      subRank: {
+        tier: '플레티넘',
+        rank: '4',
+        leaguePoints: '1LP',
+        wins: '24',
+        losses: '16',
+      }
     }));
   });
 
@@ -28,7 +42,20 @@ describe('PlayerInfoContainer', () => {
 
     expect(container).toHaveTextContent('소환사명');
     expect(container).toHaveTextContent('최하누리');
+
     expect(container).toHaveTextContent('레벨');
     expect(container).toHaveTextContent('30');
+
+    expect(container).toHaveTextContent('솔로랭크');
+    expect(container).toHaveTextContent('다이아몬드 2 75LP');
+
+    expect(container).toHaveTextContent('전적');
+    expect(container).toHaveTextContent('145승 132패');
+
+    expect(container).toHaveTextContent('자유랭크');
+    expect(container).toHaveTextContent('플레티넘 4 1LP');
+
+    expect(container).toHaveTextContent('전적');
+    expect(container).toHaveTextContent('24승 16패');
   });
 });

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -1,7 +1,11 @@
 import reducer, {
   setPlayerName,
   setSummoner,
+  setRanks,
 } from './slice';
+
+import SUMMONER from '../fixtures/summoner';
+import USER_LEAGUE_INFOS from '../fixtures/ranks';
 
 describe('reducer', () => {
   context('when previous state is undefined', () => {
@@ -10,6 +14,8 @@ describe('reducer', () => {
         userName: '',
       },
       summoner: {},
+      soloRank: {},
+      subRank: {},
     };
 
     it('returns initialState', () => {
@@ -37,18 +43,24 @@ describe('reducer', () => {
       const initialState = {
         summoner: {},
       };
-      const summoner = {
-        id: 'ROmqWcUq7lVH-iIBcatiskiO9leUlsD5SL9VQXkXPFO_Nw',
-        accountId: 'EUIJaJrzXK_sB9qfTCL7eRPIAagzFh9K9esUkb2G1Vze',
-        puuid: 'MBsxsPWzxruXkjSBghzf79BermZyogtFgrLgd7QJUS5iSXfYG2ovL7NA2yiOXNZGKdmSxZxzT9WgJQ',
-        name: '최하누리',
-        profileIconId: 4574,
-        revisionDate: 1624691287000,
-        summonerLevel: 289,
-      };
-      const state = reducer(initialState, setSummoner(summoner));
+
+      const state = reducer(initialState, setSummoner(SUMMONER));
 
       expect(state.summoner.name).toEqual('최하누리');
+    });
+  });
+
+  describe('setRanks', () => {
+    it('changes rank information', () => {
+      const initialState = {
+        soloRank: {},
+        subRank: {},
+      };
+
+      const state = reducer(initialState, setRanks(USER_LEAGUE_INFOS));
+
+      expect(state.subRank.tier).toEqual(USER_LEAGUE_INFOS[0].tier);
+      expect(state.soloRank.tier).toEqual(USER_LEAGUE_INFOS[1].tier);
     });
   });
 });

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -10,6 +10,14 @@ export async function fetchSummoners(username) {
   return response.json();
 }
 
-export async function fetchXXX() {
-  //
+export async function fetchRanks(encryptedSummonerId) {
+  const response = await fetch(`lol/league/v4/entries/by-summoner/${encryptedSummonerId}`, {
+    method: 'GET',
+    headers: {
+      Origin: 'https://developer.riotgames.com',
+      'X-Riot-Token': process.env.REACT_APP_X_RIOT_TOKEN,
+    },
+  });
+
+  return response.json();
 }

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -1,8 +1,10 @@
 import {
   fetchSummoners,
+  fetchRanks,
 } from './api';
 
 import SUMMONER from '../../fixtures/summoner';
+import RANKS from '../../fixtures/ranks';
 
 describe('api', () => {
   const mockFetch = (data) => {
@@ -20,6 +22,18 @@ describe('api', () => {
       const summoner = await fetchSummoners();
 
       expect(summoner).toEqual(SUMMONER);
+    });
+  });
+
+  describe('fetchRanks', () => {
+    beforeEach(() => {
+      mockFetch(RANKS);
+    });
+
+    it('returns user league infomations', async () => {
+      const summoner = await fetchRanks();
+
+      expect(summoner).toEqual(RANKS);
     });
   });
 });

--- a/src/slice.js
+++ b/src/slice.js
@@ -1,5 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { fetchSummoners } from './services/api';
+import {
+  fetchSummoners,
+  fetchRanks,
+} from './services/api';
 
 const { actions, reducer } = createSlice({
   name: 'players',
@@ -8,6 +11,8 @@ const { actions, reducer } = createSlice({
       userName: '',
     },
     summoner: {},
+    soloRank: {},
+    subRank: {},
   },
   reducers: {
     setPlayerName(state, { payload: userName }) {
@@ -24,19 +29,33 @@ const { actions, reducer } = createSlice({
         summoner,
       };
     },
+    setRanks(state, { payload: ranks }) {
+      const [subRank, soloRank] = ranks;
+
+      return {
+        ...state,
+        soloRank,
+        subRank,
+      };
+    },
   },
 });
 
 export const {
   setPlayerName,
   setSummoner,
+  setRanks,
 } = actions;
 
 export function loadSummoners(username) {
   return async (dispatch) => {
     const summoner = await fetchSummoners(username);
-
     dispatch(setSummoner(summoner));
+
+    if (summoner) {
+      const ranks = await fetchRanks(summoner.id);
+      dispatch(setRanks(ranks));
+    }
   };
 }
 


### PR DESCRIPTION
- 솔로랭크, 자유랭크 정보 추가
- 티어, 랭크, 전적(승/패) 확인 가능
- 검색하기 전에는 "소환사명을 검색하세요." 문구를 보여줌

### 궁금증
- API 콜하는 액션함수 안에서 2개의 API를 fetch하고 dispatch(setXXX())을 한다고 했을 때, 하나의 fetch, dispatch 로직을 If문 안에 넣어버리면 테스트코드에서 store.getActions()로 actions 값을 가져올 때, 1개만 불러와지는 이유가 뭔지 궁금합니다. (actions[0]은 setSummoner로 잘 가져오는데 actions[1]은 setRanks가 아니고 undefined가 되네용..)
```javascript
export function loadSummoners(username) {
  return async (dispatch) => {
    const summoner = await fetchSummoners(username);
    dispatch(setSummoner(summoner));

    if (summoner) {
      const ranks = await fetchRanks(summoner.id);
      dispatch(setRanks(ranks));
    }
  };
}
```