### PR TITLE
[3주차] 솔로랭크와 자유랭크 렌더링이 잘못 표시되던 에러 해결

### DIFF
--- a/src/reducers/player/slice.js
+++ b/src/reducers/player/slice.js
@@ -44,7 +44,8 @@ const { actions, reducer } = createSlice({
       };
     },
     setRanks(state, { payload: ranks }) {
-      const [subRank, soloRank] = ranks;
+      const soloRank = ranks.find(({ queueType }) => queueType === 'RANKED_SOLO_5x5');
+      const subRank = ranks.find(({ queueType }) => queueType === 'RANKED_FLEX_SR');
 
       return {
         ...state,


### PR DESCRIPTION
- ranks 응답값이 0이면 서브랭크, 1이면 솔로랭크인줄 알았는데, 값이 랜덤하여 날아오는 걸로 확인됐다.
- 그래서 큐타입에 따라 솔로, 서브 랭크를 할당해주면서 해결