### PR TITLE
[4주차] 글이 짤리거나, 특정문구일 때 줄바꿈이 적용되지 않던 버그 수정

### DIFF
--- a/src/components/games/GamePlayerProfileInfo.jsx
+++ b/src/components/games/GamePlayerProfileInfo.jsx
@@ -79,7 +79,7 @@ const SubRuneIconImg = styled.img({
 
 const ChampionNameDiv = styled.div({
   marginTop: '-4px',
-  padding: '9px',
+  padding: '14px',
   fontSize: '13px',
   color: '#555',
   textAlign: 'center',

--- a/src/components/games/GameTypeInfo.jsx
+++ b/src/components/games/GameTypeInfo.jsx
@@ -20,7 +20,7 @@ const GameTypeWrap = styled.div({
   height: 'auto',
   lineHeight: '22px',
   color: '#555',
-  fontSize: '14px',
+  fontSize: '12px',
   textAlign: 'center',
   justifyContent: 'center',
   alignSelf: 'center',


### PR DESCRIPTION
- 글자 길이가 길어지는 걸 생각하지 못하고 폰트를 키워 글자 길이가 긴 문구는 말줄임표 표시가 되던 이슈 수정
- 챔피언이 한 글자일 때, 줄바꿈이 제대로 적용되지 않아서 스타일이 깨지는 이슈 수정